### PR TITLE
refactor: extract tracing types into tracing/types.ts

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -7,12 +7,11 @@ export type {
 
 export type { HandoffConfig, HandoffTarget } from "./handoff/types";
 
+export type { TraceSpan, TraceProcessor, TracingConfig } from "./tracing/types";
+
 export type {
   RunContext,
   ModelSettings,
-  TraceSpan,
-  TraceProcessor,
-  TracingConfig,
   RunHooks,
   RunConfig,
   RunStep,

--- a/src/test/index.ts
+++ b/src/test/index.ts
@@ -1,6 +1,7 @@
 import { vi } from "vitest";
 import type { LanguageModel } from "ai";
-import type { RunContext, TraceProcessor } from "../types";
+import type { RunContext } from "../types";
+import type { TraceProcessor } from "../tracing/types";
 import type { GuardrailInput } from "../guardrail/types";
 
 export function createMockModel(): LanguageModel {

--- a/src/tracing/tracing.test.ts
+++ b/src/tracing/tracing.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
-import type { TraceSpan } from "@/types";
+import type { TraceSpan } from "@/tracing/types";
 import {
   Trace,
   trace,

--- a/src/tracing/tracing.ts
+++ b/src/tracing/tracing.ts
@@ -1,4 +1,4 @@
-import type { TraceSpan, TraceProcessor } from "@/types";
+import type { TraceSpan, TraceProcessor } from "@/tracing/types";
 
 // ---------------------------------------------------------------------------
 // ID generation

--- a/src/tracing/types.ts
+++ b/src/tracing/types.ts
@@ -1,0 +1,29 @@
+// ---------------------------------------------------------------------------
+// Tracing
+// ---------------------------------------------------------------------------
+
+export interface TraceSpan {
+  traceId: string;
+  spanId: string;
+  parentSpanId?: string;
+  name: string;
+  type: "agent" | "llm" | "tool" | "guardrail" | "handoff" | "custom";
+  startTime: number;
+  endTime?: number;
+  attributes: Record<string, unknown>;
+}
+
+export interface TraceProcessor {
+  onTraceStart(traceId: string): void | Promise<void>;
+  onSpan(span: TraceSpan): void | Promise<void>;
+  onTraceEnd(traceId: string): void | Promise<void>;
+}
+
+export interface TracingConfig {
+  enabled?: boolean;
+  traceId?: string;
+  groupId?: string;
+  processors?: TraceProcessor[];
+  redactInput?: boolean;
+  redactOutput?: boolean;
+}

--- a/src/types.ts
+++ b/src/types.ts
@@ -7,6 +7,7 @@ import type {
   LanguageModelUsage,
 } from "ai";
 import type { GuardrailResult } from "@/guardrail/types";
+import type { TracingConfig } from "@/tracing/types";
 
 // ---------------------------------------------------------------------------
 // Context
@@ -30,36 +31,6 @@ export interface RunContext<TContext = unknown> {
  * maxOutputTokens, topP, seed, retries, timeout, etc. at the agent level.
  */
 export type ModelSettings = CallSettings;
-
-// ---------------------------------------------------------------------------
-// Tracing
-// ---------------------------------------------------------------------------
-
-export interface TraceSpan {
-  traceId: string;
-  spanId: string;
-  parentSpanId?: string;
-  name: string;
-  type: "agent" | "llm" | "tool" | "guardrail" | "handoff" | "custom";
-  startTime: number;
-  endTime?: number;
-  attributes: Record<string, unknown>;
-}
-
-export interface TraceProcessor {
-  onTraceStart(traceId: string): void | Promise<void>;
-  onSpan(span: TraceSpan): void | Promise<void>;
-  onTraceEnd(traceId: string): void | Promise<void>;
-}
-
-export interface TracingConfig {
-  enabled?: boolean;
-  traceId?: string;
-  groupId?: string;
-  processors?: TraceProcessor[];
-  redactInput?: boolean;
-  redactOutput?: boolean;
-}
 
 // ---------------------------------------------------------------------------
 // Run hooks


### PR DESCRIPTION
## Summary

- Created `src/tracing/types.ts` with `TraceSpan`, `TraceProcessor`, and `TracingConfig` interfaces
- Removed these types from the shared `src/types.ts` (added import for `TracingConfig` since `RunConfig` references it)
- Updated all consumers: `tracing.ts`, `tracing.test.ts`, `test/index.ts`, and `index.ts`

Closes #8

## Test plan

- [x] `pnpm check-all` passes (format, type-check, lint, docs check, examples)
- [x] `pnpm test-all` passes (419 lib tests + all 24 example tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)