### PR TITLE
refactor: extract runner types into runner/types.ts

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -12,12 +12,6 @@ export type { TraceSpan, TraceProcessor, TracingConfig } from "./tracing/types";
 export type {
   RunContext,
   ModelSettings,
-  RunHooks,
-  RunConfig,
-  RunStep,
-  RunResult,
-  StreamEvent,
-  StreamResult,
   CallSettings,
   LanguageModel,
   ModelMessage,
@@ -25,6 +19,17 @@ export type {
   ToolSet,
   LanguageModelUsage,
 } from "./types";
+
+export type {
+  RunHooks,
+  RunConfig,
+  RunStep,
+  RunResult,
+  StreamEvent,
+  StreamResult,
+} from "./runner/types";
+
+export { MaxTurnsExceededError } from "./runner/types";
 
 export type {
   GuardrailInput,
@@ -41,7 +46,6 @@ export {
   GuardrailTripwiredError,
   ToolGuardrailTripwiredError,
 } from "./guardrail/types";
-export { MaxTurnsExceededError } from "./types";
 export { HandoffError } from "./handoff/types";
 
 export type { UIMessage } from "ai";

--- a/src/runner/runner.test.ts
+++ b/src/runner/runner.test.ts
@@ -2,7 +2,7 @@ import { describe, it, expect, vi, beforeEach } from "vitest";
 import type { LanguageModel } from "ai";
 import { z } from "zod";
 import type { RunContext, ModelMessage } from "@/types";
-import { MaxTurnsExceededError } from "@/types";
+import { MaxTurnsExceededError } from "@/runner/types";
 import type { Guardrail } from "@/guardrail/types";
 import {
   GuardrailTripwiredError,

--- a/src/runner/runner.ts
+++ b/src/runner/runner.ts
@@ -9,15 +9,15 @@ import type { LanguageModel, ModelMessage, ToolSet, UIMessage } from "ai";
 
 import type { AgentInstance } from "@/agent/types";
 import type { HandoffConfig } from "@/handoff/types";
-import type {
-  RunConfig,
-  RunContext,
-  RunResult,
-  RunStep,
-  StreamResult,
-  StreamEvent,
-} from "@/types";
-import { MaxTurnsExceededError } from "@/types";
+import type { RunContext } from "@/types";
+import {
+  MaxTurnsExceededError,
+  type RunConfig,
+  type RunResult,
+  type RunStep,
+  type StreamResult,
+  type StreamEvent,
+} from "@/runner/types";
 import {
   GuardrailTripwiredError,
   ToolGuardrailTripwiredError,

--- a/src/runner/types.ts
+++ b/src/runner/types.ts
@@ -1,0 +1,93 @@
+import type { LanguageModel, LanguageModelUsage } from "ai";
+import type { RunContext } from "@/types";
+import type { GuardrailResult } from "@/guardrail/types";
+import type { TracingConfig } from "@/tracing/types";
+
+// ---------------------------------------------------------------------------
+// Run hooks
+// ---------------------------------------------------------------------------
+
+export interface RunHooks<TContext = unknown> {
+  onRunStart?(ctx: RunContext<TContext>): void | Promise<void>;
+  onRunEnd?(
+    ctx: RunContext<TContext>,
+    result: RunResult<unknown>,
+  ): void | Promise<void>;
+  onAgentStart?(ctx: RunContext<TContext>): void | Promise<void>;
+  onAgentEnd?(ctx: RunContext<TContext>, output: string): void | Promise<void>;
+  onHandoff?(
+    ctx: RunContext<TContext>,
+    from: string,
+    to: string,
+  ): void | Promise<void>;
+  onGuardrailTripped?(
+    ctx: RunContext<TContext>,
+    result: GuardrailResult,
+  ): void | Promise<void>;
+}
+
+// ---------------------------------------------------------------------------
+// Runner
+// ---------------------------------------------------------------------------
+
+export interface RunConfig<TContext = unknown> {
+  maxTurns?: number;
+  context?: TContext;
+  model?: LanguageModel;
+  tracing?: TracingConfig;
+  hooks?: RunHooks<TContext>;
+  signal?: AbortSignal;
+}
+
+export interface RunStep {
+  type: "message" | "tool_call" | "tool_result" | "handoff" | "guardrail";
+  agent: string;
+  timestamp: number;
+  data: unknown;
+}
+
+export interface RunResult<TOutput = string> {
+  output: TOutput;
+  agent: string;
+  steps: RunStep[];
+  usage: Pick<
+    LanguageModelUsage,
+    "inputTokens" | "outputTokens" | "totalTokens"
+  >;
+  traceId?: string;
+}
+
+// ---------------------------------------------------------------------------
+// Streaming
+// ---------------------------------------------------------------------------
+
+export type StreamEvent =
+  | { type: "agent_start"; agent: string; timestamp: number }
+  | { type: "agent_end"; agent: string; timestamp: number }
+  | { type: "text_delta"; delta: string; agent: string }
+  | { type: "tool_call_start"; toolName: string; agent: string; args: unknown }
+  | { type: "tool_call_end"; toolName: string; agent: string; output: unknown }
+  | { type: "handoff"; from: string; to: string; timestamp: number }
+  | { type: "guardrail_start"; name: string; agent: string }
+  | { type: "guardrail_end"; name: string; tripwired: boolean }
+  | { type: "error"; error: Error; agent: string }
+  | { type: "done"; result: RunResult<unknown> };
+
+export interface StreamResult<TOutput = string> {
+  events: AsyncIterable<StreamEvent>;
+  result: Promise<RunResult<TOutput>>;
+}
+
+// ---------------------------------------------------------------------------
+// Error classes
+// ---------------------------------------------------------------------------
+
+export class MaxTurnsExceededError extends Error {
+  readonly maxTurns: number;
+
+  constructor(maxTurns: number) {
+    super(`Maximum turns (${maxTurns}) exceeded`);
+    this.name = "MaxTurnsExceededError";
+    this.maxTurns = maxTurns;
+  }
+}

--- a/src/types.ts
+++ b/src/types.ts
@@ -6,8 +6,6 @@ import type {
   ToolSet,
   LanguageModelUsage,
 } from "ai";
-import type { GuardrailResult } from "@/guardrail/types";
-import type { TracingConfig } from "@/tracing/types";
 
 // ---------------------------------------------------------------------------
 // Context
@@ -31,95 +29,6 @@ export interface RunContext<TContext = unknown> {
  * maxOutputTokens, topP, seed, retries, timeout, etc. at the agent level.
  */
 export type ModelSettings = CallSettings;
-
-// ---------------------------------------------------------------------------
-// Run hooks
-// ---------------------------------------------------------------------------
-
-export interface RunHooks<TContext = unknown> {
-  onRunStart?(ctx: RunContext<TContext>): void | Promise<void>;
-  onRunEnd?(
-    ctx: RunContext<TContext>,
-    result: RunResult<unknown>,
-  ): void | Promise<void>;
-  onAgentStart?(ctx: RunContext<TContext>): void | Promise<void>;
-  onAgentEnd?(ctx: RunContext<TContext>, output: string): void | Promise<void>;
-  onHandoff?(
-    ctx: RunContext<TContext>,
-    from: string,
-    to: string,
-  ): void | Promise<void>;
-  onGuardrailTripped?(
-    ctx: RunContext<TContext>,
-    result: GuardrailResult,
-  ): void | Promise<void>;
-}
-
-// ---------------------------------------------------------------------------
-// Runner
-// ---------------------------------------------------------------------------
-
-export interface RunConfig<TContext = unknown> {
-  maxTurns?: number;
-  context?: TContext;
-  model?: LanguageModel;
-  tracing?: TracingConfig;
-  hooks?: RunHooks<TContext>;
-  signal?: AbortSignal;
-}
-
-export interface RunStep {
-  type: "message" | "tool_call" | "tool_result" | "handoff" | "guardrail";
-  agent: string;
-  timestamp: number;
-  data: unknown;
-}
-
-export interface RunResult<TOutput = string> {
-  output: TOutput;
-  agent: string;
-  steps: RunStep[];
-  usage: Pick<
-    LanguageModelUsage,
-    "inputTokens" | "outputTokens" | "totalTokens"
-  >;
-  traceId?: string;
-}
-
-// ---------------------------------------------------------------------------
-// Streaming
-// ---------------------------------------------------------------------------
-
-export type StreamEvent =
-  | { type: "agent_start"; agent: string; timestamp: number }
-  | { type: "agent_end"; agent: string; timestamp: number }
-  | { type: "text_delta"; delta: string; agent: string }
-  | { type: "tool_call_start"; toolName: string; agent: string; args: unknown }
-  | { type: "tool_call_end"; toolName: string; agent: string; output: unknown }
-  | { type: "handoff"; from: string; to: string; timestamp: number }
-  | { type: "guardrail_start"; name: string; agent: string }
-  | { type: "guardrail_end"; name: string; tripwired: boolean }
-  | { type: "error"; error: Error; agent: string }
-  | { type: "done"; result: RunResult<unknown> };
-
-export interface StreamResult<TOutput = string> {
-  events: AsyncIterable<StreamEvent>;
-  result: Promise<RunResult<TOutput>>;
-}
-
-// ---------------------------------------------------------------------------
-// Error classes
-// ---------------------------------------------------------------------------
-
-export class MaxTurnsExceededError extends Error {
-  readonly maxTurns: number;
-
-  constructor(maxTurns: number) {
-    super(`Maximum turns (${maxTurns}) exceeded`);
-    this.name = "MaxTurnsExceededError";
-    this.maxTurns = maxTurns;
-  }
-}
 
 // Re-export AI SDK types used across the library so consumers only need
 // to import from this package.


### PR DESCRIPTION
## Summary

- Extracts runner-related types (`RunHooks`, `RunConfig`, `RunStep`, `RunResult`, `StreamEvent`, `StreamResult`) and `MaxTurnsExceededError` class from shared `src/types.ts` into `src/runner/types.ts`
- Updates all internal imports (`runner.ts`, `runner.test.ts`) to use `@/runner/types`
- Public API unchanged — `src/index.ts` re-exports everything from the new location

Closes #9

## Test plan

- [x] `pnpm run type-check` passes
- [x] `pnpm run lint` passes
- [x] `pnpm run test` — all 419 tests pass (14 test files)
- [x] `pnpm run check-all` — all checks clean
- [x] `pnpm run test-all` — all lib + example tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)